### PR TITLE
Use blt-t command instead of blt-toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simply download the latest [`Bluetooth Connector.alfredworkflow`](https://github
   * Optionally filter devices by name
   * Already connected devices are highlighted with a green icon
   * Battery percentage is shown if available
-* Toggle Bluetooth on or off via `blt-on`, `blt-off` or simply `blt-toggle`
+* Power Bluetooth on or off via `blt-on`, `blt-off` or simply toggle via `blt-t`
 * Workflow updates via `blt workflow:update` (Thanks to @trietsch)
 
 <img src="./preview1.jpg" width="600" alt="Preview: Alfred Bluetooth Workflow" />

--- a/info.plist
+++ b/info.plist
@@ -125,7 +125,7 @@ fi</string>
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>
-				<string>blt-toggle</string>
+				<string>blt-t</string>
 				<key>queuedelaycustom</key>
 				<integer>3</integer>
 				<key>queuedelayimmediatelyinitially</key>


### PR DESCRIPTION
@trietsch Please check if this is fine for you. @mlisitski  has proposed to just use `blt-t` instead of `blt-toggle`, as its faster to type (#1). I think it's a good idea.

We could release a new version v0.4.0 once it is merged. I was also wondering: is it necessary to always provide the `version` file when releasing a new workflow? I think it then would make sense to check this file into the git repository too.

By the way, feel free to add yourself to the license.

